### PR TITLE
make the function faster than the before

### DIFF
--- a/code/lorentz.lisp
+++ b/code/lorentz.lisp
@@ -1,29 +1,22 @@
-(defparameter dt 0.01d0)
-(defparameter n 2000000)
-(defparameter a 10.0d0)
-(defparameter b 28.0d0)
-(defparameter c (/ 8.0d0 3))
+(defconstant dt 0.01d0)
+(defconstant n 2000000)
+(defconstant a 10.0d0)
+(defconstant b 28.0d0)
+(defconstant c #.(/ 8.0d0 3)) 
 
-(defvar x (make-array (list (+ n 1)) :initial-element 0.0d0))
-(defvar y (make-array (list (+ n 1)) :initial-element 0.0d0))
-(defvar z (make-array (list (+ n 1)) :initial-element 0.0d0))
+(defun main ()
+  (declare (optimize (debug 0) (safety 0) (speed 3)))
+  (let ((x (make-array n :element-type 'double-float))
+	(y (make-array n :element-type 'double-float))
+	(z (make-array n :element-type 'double-float)))
+    (setf (aref x 0) 0.0d0
+	  (aref y 0) 1.0d0
+	  (aref z 0) 1.05d0)
+    (dotimes (i #.(1- n))
+      (declare (fixnum i))
+      (setf (aref x (1+ i)) (+ (aref x i) (* #.dt (- (* #.a (aref y i)) (* #.a (aref x i)))))
+	    (aref y (1+ i)) (+ (aref y i) (* #.dt (- (* #.b (aref x i)) (* (aref x i) (aref z i)) (aref y i))))
+	    (aref z (1+ i)) (+ (aref z i) (* #.dt (- (* (aref x i) (aref y i)) (* #.c (aref z i)))))))
+    ))
 
-
-(setf (aref x 1) 0.0d0)
-(setf (aref y 1) 1.0d0)
-(setf (aref z 1) 1.05d0)
-
-(time
- (loop for i from 1 to (1- n)
-    do 
-      (setf (aref x (1+ i))
-            (+ (aref x i)
-               (* dt (+ (- (* a (aref x i))) (* a (aref y i))))))
-      (setf (aref y (1+ i))
-            (+ (aref y i)
-               (* dt (+ (- (* (aref x i) (aref z i))) (* b (aref x i))  (- (aref y i))))))
-      (setf (aref z (1+ i))
-            (+ (aref z i)
-               (* dt (- (* (aref x i) (aref y i)) (* c (aref z i))))))))
-
-
+(time (main))


### PR DESCRIPTION
以前のコードに以下の最適化を施したところ34倍高速になりましたので報告します。

- 定数化
- 定数のインライン展開
- 配列の型指定
- 大域変数の除去

これでJuliaの最高速との差が３倍以内になりましたね。

- オリジナル

```
Evaluation took:
  1.546 seconds of real time
  1.539931 seconds of total run time (1.321762 user, 0.218169 system)
  [ Run times consist of 0.793 seconds GC time, and 0.747 seconds non-GC time. ]
  99.61% CPU
  2,783,102,624 processor cycles
  607,985,680 bytes consed
```
- 最適化後

```
Evaluation took:
  0.045 seconds of real time
  0.044398 seconds of total run time (0.026790 user, 0.017608 system)
  97.78% CPU
  80,243,036 processor cycles
  48,000,048 bytes consed
```